### PR TITLE
remove dependency on mime-types

### DIFF
--- a/rgeoserver.gemspec
+++ b/rgeoserver.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency "activemodel", "~> 3.2.0"
   s.add_dependency "activesupport", "~> 3.2.0"
   s.add_dependency "confstruct", "~> 0.2.0"
-  s.add_dependency "mime-types", "~> 2.0"
   s.add_dependency "nokogiri", "~> 1.6.0"
   s.add_dependency "rest-client", "~> 1.6.0"
   s.add_dependency "rgeo", "~> 0.3.0"


### PR DESCRIPTION
mime-types doesn't appear to actually be used directly anywhere in
rgeoserver, so remove it as a dependency.

This change is necessary to use rgeoserver in environments where you don't control what rest-client version you have. My example use case is Chef, where I use rgeoserver to automatically configure a GeoServer in a Chef recipe. Recent versions of Chef come with rest-client 1.6.7, I believe, which is incompatible with mime-types 2.x.

Since rgeoserver already depends on rest-client, just let that determine which version of mime-types to install.