### PR TITLE
Use GeoServer default admin password

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -3,7 +3,7 @@ geoserver:
   url: "http://localhost:8080/geoserver/rest"
   # Optional user/password, set to false to disable
   user: "admin"
-  password: "admin"
+  password: "geoserver"
   # Set to your GWC server, or "builtin" for the one bundled with GeoServer
   geowebcache_url: "builtin"
 


### PR DESCRIPTION
The current admin password default of `admin` results in the following on a vanilla install of geoserver:

```
[1] pry(main)> catalog = RGeoServer::Catalog.new
[2] pry(main)> catalog.get_default_workspace
RestClient::Unauthorized: 401 Unauthorized
```

This is because GeoServer currently defaults to using `geoserver` as the password for
the admin user. This change allows the creation of a Catalog
object using the defaults again.